### PR TITLE
replace in cmdline.txt and fstab rather than templating out

### DIFF
--- a/create-factory-reset
+++ b/create-factory-reset
@@ -8,16 +8,24 @@ set -eu -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+# output formatting functions like pr_header, pr_debug etc
 source "$DIR/lib/display_funcs"
+# handles options processing for script
 source "$DIR/lib/usage.sh"
+# variables derived from setup options and various constants
 source "$DIR/lib/setup.sh"
+# bunch of utility functions for inspecting/setting values etc
 source "$DIR/lib/utils.sh"
+# this is where the main logic lives
 source "$DIR/lib/stages.sh"
+# initial attempt at having some unit tests
 source "$DIR/lib/tests.sh"
 
+# dump variables as seen after options and defauls processing
 show_setup_var_summary
 
 # this is to cleanup any previous runs that didn't run cleanup at the end
+# this won't cleanup mounts from different image to the one give with -i
 if [ ! -z "${OPTION_CLEANUP_PRE}" ]; then
   cleanup
 fi
@@ -36,16 +44,18 @@ fi
 # these are needed to create the copy of the original
 [ "$OPT_GET_PART_FOR_ORIG" ] && get_partitions_for_original
 
-# extract start/sizes for lite image (if used)
+# extract part start/sizes for lite image (if used)
 # we need the size of the root partition from the lite image
 # to calculate the total space required lite+recovery.zip+free space
 [ "$OPT_GET_PART_FOR_LITE" ] && get_partitions_for_lite
 
 # to avoid conflicts, generate uuids for boot, recovery, root partions
-# @TODO not sure if this is actually needed.. to validate...
+# @TODO not sure if this is actually needed.. to check that...
+# currently the only thing that seems absolutely necessary, is that the
+# root/recovery parts of the recovery image have unique UUIDs
 [ "$OPT_MAKE_UUIDS" ] && make_uuids
 
-# mount the boot and root partiions of source img to loopback devices
+# mount the boot and root partiions of source img to loopback devices ro
 [ "$OPT_MOUNT_ORIG" ] && make_loop_and_mount_original
 
 # make a writable copy of the source image and mount it
@@ -55,12 +65,16 @@ fi
 [ "$OPT_COPY_TO_COPY" ] && copy_original_to_copy
 
 # insert the generated UUID into the rootfs fstab from those generated earlier
+# @TODO if this is going to be done, it needs to search and replace rather than
+# template out the fstab... disabled as will probably break things as it is
 # [ "$OPT_FIX_ROOTFS_FSTAB" ] && fix_copy_rootfs_fstab
 
 # the resize script fails if the root partiion is not in position 2
 # so this needs to be copied into the copy image
 # @TODO not sure if this is still needed, as the current script checks the
 # partition number of the root partition.
+# the only thing this script does now (??) is add some sleeps to make the output
+# more useful in failure situations
 [ "$OPT_FIX_RESIZE_SCRIPT" ] && fix_resize_script
 
 # zip the copy of the rootfs for use in restoring

--- a/create-factory-reset
+++ b/create-factory-reset
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# this whole thing has become ridiculously complicated
+# I think I should redo it in python
+
 # fail on errors, undefined variables, and errors in pipes
 set -eu -o pipefail
 
@@ -10,6 +13,7 @@ source "$DIR/lib/usage.sh"
 source "$DIR/lib/setup.sh"
 source "$DIR/lib/utils.sh"
 source "$DIR/lib/stages.sh"
+source "$DIR/lib/tests.sh"
 
 show_setup_var_summary
 
@@ -23,12 +27,18 @@ if [ "$OPT_DO_CHECKS" ] ; then
   check_sources
 fi
 
+if [ ! -z "${OPT_RUN_TESTS}" ]; then
+  run_tests
+  exit 0
+fi
+
 # extract the partition start/sizes for the source image
 # these are needed to create the copy of the original
 [ "$OPT_GET_PART_FOR_ORIG" ] && get_partitions_for_original
 
 # extract start/sizes for lite image (if used)
 # we need the size of the root partition from the lite image
+# to calculate the total space required lite+recovery.zip+free space
 [ "$OPT_GET_PART_FOR_LITE" ] && get_partitions_for_lite
 
 # to avoid conflicts, generate uuids for boot, recovery, root partions
@@ -45,11 +55,11 @@ fi
 [ "$OPT_COPY_TO_COPY" ] && copy_original_to_copy
 
 # insert the generated UUID into the rootfs fstab from those generated earlier
-[ "$OPT_FIX_ROOTFS_FSTAB" ] && fix_copy_rootfs_fstab
+# [ "$OPT_FIX_ROOTFS_FSTAB" ] && fix_copy_rootfs_fstab
 
 # the resize script fails if the root partiion is not in position 2
 # so this needs to be copied into the copy image
-# @TODO not sure if this is still needed, as the current script checks the 
+# @TODO not sure if this is still needed, as the current script checks the
 # partition number of the root partition.
 [ "$OPT_FIX_RESIZE_SCRIPT" ] && fix_resize_script
 
@@ -69,6 +79,8 @@ fi
 # copy the various source partiions into the restore image
 # mount the partitions for further editing
 [ "$OPT_COPY_TO_RESTORE" ] && copy_to_restore
+
+[ "$OPT_FIXUP_RECOVERY_ROOTFS" ] && fixup_fstab_in_recovery_rootfs
 
 # edit the cmdline.txt file for correct partition
 [ "$OPT_FIX_CMDLINE_TXT" ] && overwrite_cmdline_for_boot

--- a/factory_reset
+++ b/factory_reset
@@ -278,14 +278,14 @@ if [ "${OPT_RESET}" ] ; then
     # @TODO this is repeated in a bunch of places, put in libs somewhere?
     # check that /boot device mount was a partuuid
     if egrep '^PARTUUID=' "$fstab_file" | grep '/boot' ; then
-      echo "/boot was a PARTUUID"
+      echo "${ORANGEFG}/boot was a PARTUUID${RESET}"
       sed -i -E "s|^PARTUUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|PARTUUID=${boot_partuuid}      /boot     \3|" "$fstab_file"
       fixed_boot=1
     fi
 
     # check that /boot device mount was a uuid
     if egrep '^UUID=' "$fstab_file" | grep '/boot' ; then
-      echo "/boot was a UUID"
+      echo "${ORANGEFG}/boot was a UUID${RESET}"
       sed -i -E "s|^UUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|UUID=${boot_uuid}      /boot     \3|" "$fstab_file"
       fixed_boot=1
     fi

--- a/factory_reset
+++ b/factory_reset
@@ -14,6 +14,7 @@ OPT_COPY_WIFI=""
 OPT_DEBUG=""
 OPT_BOOT_RECOVERY=""
 OPT_BOOT_ROOT=""
+OPT_NO_REBOOT=""
 
     GREENFG=$(tput setaf 2      2>/dev/null )
     GREENBG=$(tput setab 2      2>/dev/null )
@@ -50,15 +51,17 @@ OPTIONS:
 
 ADVANCED OPTIONS:
 
-   --debug                output a lot of messages which indicate what is
-                          happening during the process
-
-   --boot-to-recovery     don't initiate reest, just reboot into the recovery
-                          partition (mutually exclusive with --reset)
-
-   --boot-to-rootfs       boot back to rootfs (without reset)
-                          this only makes any sense when in recovery
+   --no-reboot            do everything, but don't reboot at the end, to allow
+                          for inspection
 EOF
+
+# I think these other options are broken at the moment
+  #  --boot-to-recovery     don't initiate reest, just reboot into the recovery
+  #                         partition (mutually exclusive with --reset)
+
+  #  --boot-to-rootfs       boot back to rootfs (without reset)
+  #                         this only makes any sense when in recovery
+
 }
 
 for ((i=1; i<=$#; i++))
@@ -101,6 +104,10 @@ do
       OPT_BOOT_ROOT=1
     ;;
 
+    --no-reboot)
+      OPT_NO_REBOOT=1
+    ;;
+
     *)
     echo “unrecognised option: $ARG”
     echo
@@ -129,101 +136,202 @@ echo "factory restore script - resetting"
 
 sleep 2
 
-if [ "${OPT_BOOT_RECOVERY}" ] ; then
-  echo "booting to recovery"
-
-  cp -f /boot/cmdline.txt_recovery /boot/cmdline.txt
-
-  sed -i "s/XXXYYYXXX/$(blkid -o export  \
-        /dev/disk/by-label/recoveryfs | \
-          egrep '^PARTUUID=' | cut -d'=' -f2)/g" /boot/cmdline.txt
-
-  sed -i "s/init=[^[:space:]]*//g"  /boot/cmdline.txt
-
-  cat /boot/cmdline.txt
-  echo "rebooting in 10..."
-  sleep 10
-  touch /boot/ssh
-  reboot
-
-  exit 0
-fi
-
 if [ "${OPT_BOOT_ROOT}" ] ; then
   echo "booting to rootfs"
 
-  ROOTPARTUUID="$(blkid -s PARTUUID -o value /dev/disk/by-label/rootfs)"
-  sed -i "s/root=[^[:space:]]*/root=PARTUUID=${ROOTPARTUUID}/"  /boot/cmdline.txt
-  sed -i "s/init=[^[:space:]]*//"  /boot/cmdline.txt
+  ROOT_PART_PARTUUID=$(blkid -s PARTUUID -o value \
+        /dev/disk/by-label/rootfs)
+
+  ROOT_PART_UUID=$(blkid -s UUID -o value \
+        /dev/disk/by-label/rootfs)
+
+  if grep 'root=PARTUUID' /boot/cmdline.txt; then
+    sed -i -E "s|(root=PARTUUID)=([^[:space:]]+)|root=PARTUUID=$ROOT_PART_PARTUUID|" \
+          /boot/cmdline.txt
+  elif grep 'root=UUID' /boot/cmdline.txt; then
+    sed -i -E "s|(root=UUID)=([^[:space:]]+)|root=UUID=$ROOT_PART_UUID|" \
+          /boot/cmdline.txt
+  else
+    echo "unable to find UUID or PARTUUID in cmdline.txt"
+    echo "current cmdline.txt is"
+    cat /boot/cmdline.txt
+    exit 99
+  fi
+
+  # sed -i "s/init=[^[:space:]]*//"  /boot/cmdline.txt
 
   cat /boot/cmdline.txt
   echo "rebooting in 10..."
   sleep 10
-  reboot
+  [ ! "${OPT_NO_REBOOT}" ] && reboot || true
+
+  exit 0
+fi
+
+if [ "${OPT_BOOT_RECOVERY}" ] ; then
+  echo "booting to recovery"
+
+  echo "show current cmdline.txt"
+  cat /boot/cmdline.txt
+  echo ""
+
+  RECOVERY_PART_PARTUUID=$(blkid -s PARTUUID -o value \
+        /dev/disk/by-label/recoveryfs)
+
+  RECOVERY_PART_UUID=$(blkid -s UUID -o value \
+        /dev/disk/by-label/recoveryfs)
+
+  if grep 'root=PARTUUID' /boot/cmdline.txt; then
+    sed -i -E "s|(root=PARTUUID)=([^[:space:]]+)|root=PARTUUID=$RECOVERY_PART_PARTUUID|" \
+          /boot/cmdline.txt
+  elif grep 'root=UUID' /boot/cmdline.txt; then
+    sed -i -E "s|(root=UUID)=([^[:space:]]+)|root=UUID=$RECOVERY_PART_UUID|" \
+          /boot/cmdline.txt
+  else
+    echo "unable to find UUID or PARTUUID in cmdline.txt"
+    echo "current cmdline.txt is"
+    cat /boot/cmdline.txt
+    exit 99
+  fi
+
+  cat /boot/cmdline.txt
+  [ ! "${OPT_NO_REBOOT}" ] && echo "rebooting in 10..." || true
+  [ ! "${OPT_NO_REBOOT}" ] && sleep 10 || true
+  touch /boot/ssh
+
+  [ ! "${OPT_NO_REBOOT}" ] && reboot || true
 
   exit 0
 fi
 
 
+if [ "${OPT_RESET}" ] ; then
+    echo "resetting"
 
-echo "show original cmdline.txt"
-cat /boot/cmdline.txt
-echo ""
+    RECOVERY_PART_PARTUUID=$(blkid -s PARTUUID -o value \
+          /dev/disk/by-label/recoveryfs)
 
-cp -f /etc/fstab /boot/fstab_original
+    RECOVERY_PART_UUID=$(blkid -s UUID -o value \
+          /dev/disk/by-label/recoveryfs)
 
-cp -f /boot/cmdline.txt /boot/cmdline.txt_original
-cp -f /boot/cmdline.txt_recovery /boot/cmdline.txt
+    if grep 'root=PARTUUID' /boot/cmdline.txt; then
+      sed -i -E "s|(root=PARTUUID)=([^[:space:]]+)|root=PARTUUID=$RECOVERY_PART_PARTUUID|" \
+            /boot/cmdline.txt
+    elif grep 'root=UUID' /boot/cmdline.txt; then
+      sed -i -E "s|(root=UUID)=([^[:space:]]+)|root=UUID=$RECOVERY_PART_UUID|" \
+            /boot/cmdline.txt
+    else
+      echo "unable to find UUID or PARTUUID in cmdline.txt"
+      echo "current cmdline.txt is"
+      cat /boot/cmdline.txt
+      exit 99
+    fi
 
-sed -i "s/XXXYYYXXX/$(blkid -o export  \
-      /dev/disk/by-label/recoveryfs | \
-        egrep '^PARTUUID=' | cut -d'=' -f2)/g" /boot/cmdline.txt
+    # remove init option if we are still pre-resize mode. this would have to
+    # be done manually from raspi-config after this...
+    sed -i "s/init=[^[:space:]]*//g"  /boot/cmdline.txt
 
-# echo "show blkid"
-# blkid
-# echo ""
+    # add resize init script to end of boot option
+    echo "$(cat /boot/cmdline.txt) init=/usr/lib/raspi-config/init_restore.sh" > /boot/cmdline.txt_tmp
+    cp -f /boot/cmdline.txt_tmp /boot/cmdline.txt
 
-echo "show rootfs fstab"
-cat /etc/fstab | egrep -v '^#'
-echo ""
+    echo "show rootfs fstab"
+    cat /etc/fstab | egrep -v '^#'
+    echo ""
 
-# echo "show recoveryfs fstab"
-# mkdir -p /mnt/recoveryfs
-# mount /dev/disk/by-label/recoveryfs /mnt/recoveryfs
-# cat /mnt/recoveryfs/etc/fstab
+    echo "show recoveryfs fstab"
+    mkdir -p /mnt/recoveryfs
+    mount /dev/disk/by-label/recoveryfs /mnt/recoveryfs  || \
+        { [ $? -eq 32 ] && echo "already mounted" || \
+            { echo "some other error" ;  exit 99 ;}  }
 
-# umount -f /mnt/recoveryfs
-# echo ""
+    cat /mnt/recoveryfs/etc/fstab
 
-echo "show current cmdline.txt"
-cat /boot/cmdline.txt
-echo ""
 
-[[ "${OPT_COPY_PI_PASS}" ]] && {
-  echo "copy pi pass is set"
-  cat /etc/shadow | egrep '^pi' | awk -F: '{print $2}' > /boot/restore_pi_pass
-  echo "value of pi pass"
-  cat /boot/restore_pi_pass
-}
+    P1_UUID="$(blkid -o value -s UUID /dev/mmcblk0p1)"
+    P2_UUID="$(blkid -o value -s UUID /dev/mmcblk0p2)"
 
-[[ "${OPT_COPY_ROOT_PASS}" ]] && {
-  echo "copy root pass is set"
-  cat /etc/shadow | egrep '^root' | awk -F: '{print $2}' > /boot/restore_root_pass
-  echo "value of root pass"
-  cat /boot/restore_root_pass
-}
+    P1_PARTUUID="$(blkid -o value -s PARTUUID /dev/mmcblk0p1)"
+    P2_PARTUUID="$(blkid -o value -s PARTUUID /dev/mmcblk0p2)"
 
-[[ "${OPT_COPY_WIFI}" ]] && {
-  echo "copy wifi settings is set"
-  if [ -f /etc/wpa_supplicant/wpa_supplicant.conf ] ; then
-    echo "wpa file exists"
-    cp /etc/wpa_supplicant/wpa_supplicant.conf \
-        /boot/wpa_supplicant.conf
+    # this junk copied from utils methds. needs @TODO refactoring
+    fstab_file=/mnt/recoveryfs/etc/fstab
+    boot_partuuid=$P1_PARTUUID
+    boot_uuid=$P1_UUID
+    root_partuuid=$P2_PARTUUID
+    root_uuid=$P2_UUID
 
-    echo "current contents of wpa_supplicant in /boot"
-    cat /boot/wpa_supplicant.conf
-  fi
-}
+    [ "${boot_partuuid}" ] || { echo "value not populated - ${boot_partuuid}"; exit 99 ; }
+    [ "${boot_uuid}" ] || { echo "value not populated - ${boot_uuid}"; exit 99 ; }
+    [ "${root_partuuid}" ] || { echo "value not populated - ${root_partuuid}"; exit 99 ; }
+    [ "${root_uuid}" ] || { echo "value not populated - ${root_uuid}"; exit 99 ; }
+
+    if [ ! -f "$fstab_file" ] ; then
+      echo "$fstab_file is not a file"
+      exit 99
+    fi
+
+    # check that /boot device mount was a partuuid
+    if egrep '^PARTUUID=' "$fstab_file" | grep '/boot' ; then
+      echo "/boot was a PARTUUID"
+      sed -i -E "s|^PARTUUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|PARTUUID=${boot_partuuid}      /boot     \3|" "$fstab_file"
+      fixed_boot=1
+    fi
+
+    # check that / device mount was a partuuid
+    if egrep '^PARTUUID=' "$fstab_file" | egrep '[[:space:]]/[[:space:]]' ; then
+      echo "/ was a PARTUUID"
+      sed -i -E "s|^PARTUUID=([^[:space:]]+)[[:space:]]+/([[:space:]]+)(.*)|PARTUUID=${root_partuuid}      /     \3|" "$fstab_file"
+      fixed_root=1
+    fi
+
+    # check that /boot device mount was a uuid
+    if egrep '^UUID=' "$fstab_file" | grep '/boot' ; then
+      echo "/boot was a UUID"
+      sed -i -E "s|^UUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|UUID=${boot_uuid}      /boot     \3|" "$fstab_file"
+      fixed_boot=1
+    fi
+
+    # check that / device mount was a uuid
+    if egrep '^UUID=' "$fstab_file" | egrep '[[:space:]]/[[:space:]]' ; then
+      echo "/ was a UUID"
+      sed -i -E "s|^UUID=([^[:space:]]+)[[:space:]]+/([[:space:]]+)(.*)|UUID=${root_partuuid}      /     \3|" "$fstab_file"
+      fixed_root=1
+    fi
+
+    umount -f /mnt/recoveryfs
+    echo ""
+
+
+    echo "show current cmdline.txt"
+    cat /boot/cmdline.txt
+    echo ""
+
+    [[ "${OPT_COPY_PI_PASS}" ]] && {
+      echo "copy pi pass is set"
+      cat /etc/shadow | egrep '^pi' | awk -F: '{print $2}' > /boot/restore_pi_pass
+      echo "value of pi pass"
+      cat /boot/restore_pi_pass
+    }
+
+    [[ "${OPT_COPY_ROOT_PASS}" ]] && {
+      echo "copy root pass is set"
+      cat /etc/shadow | egrep '^root' | awk -F: '{print $2}' > /boot/restore_root_pass
+      echo "value of root pass"
+      cat /boot/restore_root_pass
+    }
+
+    [[ "${OPT_COPY_WIFI}" ]] && {
+      echo "copy wifi settings is set"
+      if [ -f /etc/wpa_supplicant/wpa_supplicant.conf ] ; then
+        echo "wpa file exists"
+        cp /etc/wpa_supplicant/wpa_supplicant.conf \
+            /boot/wpa_supplicant.conf
+
+        echo "current contents of wpa_supplicant in /boot"
+        cat /boot/wpa_supplicant.conf
+      fi
+    }
 
 cat <<EOF
 OPT_COPY_PI_PASS=${OPT_COPY_PI_PASS}
@@ -231,9 +339,10 @@ OPT_COPY_ROOT_PASS=${OPT_COPY_ROOT_PASS}
 OPT_COPY_WIFI=${OPT_COPY_WIFI}
 EOF
 
-echo "rebooting in 10..."
-sleep 10
 
+    [ ! "${OPT_NO_REBOOT}" ] && echo "rebooting in 10..." || true
+    [ ! "${OPT_NO_REBOOT}" ] && sleep 10 || true
 
-reboot
-exit 0
+    [ ! "${OPT_NO_REBOOT}" ] && reboot || true
+    exit 0
+fi

--- a/factory_reset
+++ b/factory_reset
@@ -37,30 +37,34 @@ usage: $0 options
 Calling this script causes the rPi to reboot and factory reset. All data is lost
 
 OPTIONS:
-   --reset                set this option to proceed with reset,
-                          otherwise script will exit and do nothing
-                          (mutually exclusive with --boot-to-recovery )
+   --reset                 set this option to proceed with reset,
+                           otherwise script will exit and do nothing
+                           (mutually exclusive with --boot-to-recovery )
 
-   --copy-pi-password     during the reset, preserve the pi user password
+   --copy-pi-password      during the reset, preserve the pi user password
 
-   --copy-root-password   during the reset, preserve the root password
+   --copy-root-password    during the reset, preserve the root password
 
-   --copy-wifi            preserve the current wifi settings
+   --copy-wifi             preserve the current wifi settings
 
-   --copy-all             preserve pi, root and wifi settings
+   --copy-all              preserve pi, root and wifi settings
 
 ADVANCED OPTIONS:
 
-   --no-reboot            do everything, but don't reboot at the end, to allow
-                          for inspection
+   --no-reboot             do everything, but don't reboot at the end, to allow
+                           for inspection
+
+POSSIBLY BROKEN OPTIONS:
+
+   --debug                 enable debugging verbosity
+
+   --boot-to-recovery      don't initiate reest, just reboot into the recovery
+                           partition (mutually exclusive with --reset)
+
+   --boot-to-root          boot back to rootfs (without reset)
+                           this only makes any sense when in recovery
+
 EOF
-
-# I think these other options are broken at the moment
-  #  --boot-to-recovery     don't initiate reest, just reboot into the recovery
-  #                         partition (mutually exclusive with --reset)
-
-  #  --boot-to-rootfs       boot back to rootfs (without reset)
-  #                         this only makes any sense when in recovery
 
 }
 
@@ -271,10 +275,18 @@ if [ "${OPT_RESET}" ] ; then
       exit 99
     fi
 
+    # @TODO this is repeated in a bunch of places, put in libs somewhere?
     # check that /boot device mount was a partuuid
     if egrep '^PARTUUID=' "$fstab_file" | grep '/boot' ; then
       echo "/boot was a PARTUUID"
       sed -i -E "s|^PARTUUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|PARTUUID=${boot_partuuid}      /boot     \3|" "$fstab_file"
+      fixed_boot=1
+    fi
+
+    # check that /boot device mount was a uuid
+    if egrep '^UUID=' "$fstab_file" | grep '/boot' ; then
+      echo "/boot was a UUID"
+      sed -i -E "s|^UUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|UUID=${boot_uuid}      /boot     \3|" "$fstab_file"
       fixed_boot=1
     fi
 
@@ -283,13 +295,6 @@ if [ "${OPT_RESET}" ] ; then
       echo "/ was a PARTUUID"
       sed -i -E "s|^PARTUUID=([^[:space:]]+)[[:space:]]+/([[:space:]]+)(.*)|PARTUUID=${root_partuuid}      /     \3|" "$fstab_file"
       fixed_root=1
-    fi
-
-    # check that /boot device mount was a uuid
-    if egrep '^UUID=' "$fstab_file" | grep '/boot' ; then
-      echo "/boot was a UUID"
-      sed -i -E "s|^UUID=([^[:space:]]+)[[:space:]]+/boot([[:space:]]+)(.*)|UUID=${boot_uuid}      /boot     \3|" "$fstab_file"
-      fixed_boot=1
     fi
 
     # check that / device mount was a uuid

--- a/lib/stages.sh
+++ b/lib/stages.sh
@@ -169,7 +169,7 @@ function make_uuids(){
 #
 function make_loop_and_mount_original(){
 
-  pr_header "mount the original img readonly on loopback"
+  pr_header "mount the original image readonly on loopback"
 
   LOOP_ORIG=$(losetup \
         --read-only \

--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+
+# test for the function to swap in a new uuid or partuuid
+test_replace_uuid_in_cmdline(){
+
+  pr_header "test replacing uuid/partuuid in cmdline.txt"
+
+  tmpfile1=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile2=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile3=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile4=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile5=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile6=$(mktemp /tmp/cmdline_test.XXXXXX)
+
+  new_partuuid="aabbccdd-03"
+  new_uuid="e10a8a6e-2b7a-11ec-9a3f-001fb5278d0c"
+
+  echo "console=serial0,115200 console=tty1 root=PARTUUID=13abc512-02 rootfstype=ext4 elevator=deadline fsck.repair=yes" > $tmpfile1
+
+  echo "console=serial0,115200 console=tty1 root=UUID=1c92521c-4882-4f09-ac33-fb0a12086a7e rootfstype=ext4 elevator=deadline fsck.repair=yes" > $tmpfile2
+
+  echo "console=serial0,115200 console=tty1 root=PARTUUID=${new_partuuid} rootfstype=ext4 elevator=deadline fsck.repair=yes" > $tmpfile3
+
+  echo "console=serial0,115200 console=tty1 root=UUID=${new_uuid} rootfstype=ext4 elevator=deadline fsck.repair=yes" > $tmpfile4
+
+  # cat $tmpfile1
+  sed -E "s|(root=PARTUUID)=([^[:space:]]+)|root=PARTUUID=$new_partuuid|" $tmpfile1 > $tmpfile5
+
+  # cat $tmpfile2
+  sed -E "s|(root=UUID)=([^[:space:]]+)|root=UUID=$new_uuid|" $tmpfile2 > $tmpfile6
+
+  pr_h3 "cmp compare PARTUUID"
+  cmp $tmpfile3 $tmpfile5 || {
+    echo "didn't match"
+    cat $tmpfile3
+    cat $tmpfile5
+    exit 1
+  }
+
+  pr_h3 "cmp compare UUID"
+  cmp $tmpfile4 $tmpfile6 || {
+    echo "didn't match"
+    cat $tmpfile4
+    cat $tmpfile6
+    exit 1
+  }
+
+  # cat $tmpfile3
+  # cat $tmpfile4
+
+  rm "$tmpfile1"
+  rm "$tmpfile2"
+  rm "$tmpfile3"
+  rm "$tmpfile4"
+  rm "$tmpfile5"
+  rm "$tmpfile6"
+}
+
+# test for the function to swap in a new uuid or partuuid
+test_replace_uuid_in_cmdline(){
+
+  pr_header "test replacing uuid/partuuid in fstab"
+
+  tmpfile1=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile2=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile3=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile4=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile5=$(mktemp /tmp/cmdline_test.XXXXXX)
+  tmpfile6=$(mktemp /tmp/cmdline_test.XXXXXX)
+
+cat << EOF > $tmpfile1
+proc            /proc           proc    defaults          0       0
+PARTUUID=9730496b-01  /boot           vfat    defaults          0       2
+PARTUUID=9730496b-02  /               ext4    defaults,noatime  0       1
+EOF
+
+
+
+  fixup_fstab $tmpfile1 xxx  xxx2 yyy1 yyy2
+
+
+  rm "$tmpfile1"
+  rm "$tmpfile2"
+  rm "$tmpfile3"
+  rm "$tmpfile4"
+  rm "$tmpfile5"
+  rm "$tmpfile6"
+}
+
+
+run_tests(){
+
+  test_replace_uuid_in_cmdline
+
+}
+
+

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -71,7 +71,7 @@ OPT_POST_SUMMARY=""
 OPT_RUN_TESTS=""
 
 # no idea what half of these options were supposed to do
-# would be nice to switch
+# would be nice to switch to something that handled long opts
 
 while getopts “arhcsi:l:p:vetz” OPTION
 do

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -47,7 +47,7 @@ OPTION_DO_MAIN=""           # unset this to not do the main section
 # these are used to override different sections
 # mostly for debugging/development
 OPT_DO_CHECKS=""            # whether to do file and package checks
-OPT_GET_PART_FOR_ORIG=""   
+OPT_GET_PART_FOR_ORIG=""
 OPT_GET_PART_FOR_LITE=""    # get the lite image partition sizes
 OPT_MAKE_UUIDS=""
 OPT_MOUNT_ORIG=""
@@ -60,6 +60,7 @@ OPT_MOUNT_LITE=""
 OPT_GET_RECOVERY_SIZES=""
 OPT_MOUNT_RESTORE=""
 OPT_COPY_TO_RESTORE=""
+OPT_FIXUP_RECOVERY_ROOTFS=""
 
 OPT_FIX_CMDLINE_TXT=""
 OPT_MAKE_RESTORE_SCRIPT=""
@@ -67,7 +68,12 @@ OPT_MAKE_RECOVERY_SCRIPT=""
 
 OPT_POST_SUMMARY=""
 
-while getopts “arhcsi:l:p:ve” OPTION
+OPT_RUN_TESTS=""
+
+# no idea what half of these options were supposed to do
+# would be nice to switch
+
+while getopts “arhcsi:l:p:vetz” OPTION
 do
      case $OPTION in
          h)
@@ -76,7 +82,7 @@ do
            exit 1
         ;;
          a)
-            
+
             OPTION_CLEANUP_PRE=1
             OPT_DO_CHECKS="1"
             OPT_GET_PART_FOR_ORIG="1"
@@ -94,6 +100,7 @@ do
             OPT_FIX_CMDLINE_TXT="1"
             OPT_MAKE_RESTORE_SCRIPT="1"
             OPT_MAKE_RECOVERY_SCRIPT="1"
+            OPT_FIXUP_RECOVERY_ROOTFS="1"
 
             #
             OPT_GET_PART_FOR_LITE="1"
@@ -129,6 +136,15 @@ do
             OPT_USE_LITE=1
             OPT_GET_PART_FOR_LITE="1"
             OPT_MOUNT_LITE="1"
+         ;;
+         # don't do slow operations, used for testing
+         z)
+            OPT_MAKE_RECOVERY_ZIP=""
+         ;;
+         # run tests and exit
+         t)
+            OPT_RUN_TESTS="1"
+          break  # don't process any more options
          ;;
          ?)
             # echo "in usage"


### PR DESCRIPTION
originally the script templated out the /boot/cmdline.txt and /etc/fstab file as they seemed to be fairly static (and it was easier to code)

however it looks like sometimes `root=UUIID=` is used and sometimes `root=PARTUUID=` so these changes support just updating that value, rather than messing with the whole file